### PR TITLE
Fix TypeScript errors in test files

### DIFF
--- a/src/contexts/AppContext.test.tsx
+++ b/src/contexts/AppContext.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../hooks/usePdfDocument', () => ({
     pdfDocument: null,
     loadState: { isLoading: false, error: null, progress: 0, isLoaded: false },
     loadPdf: vi.fn(),
+    clearPdf: vi.fn(),
   })),
 }));
 
@@ -153,6 +154,7 @@ describe('AppContext', () => {
         pdfDocument: mockPdfDocument,
         loadState: { isLoading: false, error: null, progress: 0, isLoaded: true },
         loadPdf: vi.fn(),
+        clearPdf: vi.fn(),
       });
 
       const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -194,6 +196,7 @@ describe('AppContext', () => {
         pdfDocument: null,
         loadState: { isLoading: false, error: null, progress: 0, isLoaded: false },
         loadPdf: mockLoadPdf,
+        clearPdf: vi.fn(),
       });
 
       const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -283,6 +286,7 @@ describe('AppContext', () => {
         pdfDocument: mockPdfDocument,
         loadState: { isLoading: false, error: null, progress: 0, isLoaded: true },
         loadPdf: vi.fn(),
+        clearPdf: vi.fn(),
       });
 
       const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -335,6 +339,7 @@ describe('AppContext', () => {
         pdfDocument: mockPdfDocument,
         loadState: { isLoading: false, error: null, progress: 0, isLoaded: true },
         loadPdf: vi.fn(),
+        clearPdf: vi.fn(),
       });
 
       const wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/src/hooks/useKeyboard.test.ts
+++ b/src/hooks/useKeyboard.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useKeyboard } from './useKeyboard';
+import type { ReadingDirection } from '../types/settings';
 
 // Helper function to create mock event
 const createKeyboardEvent = (key: string, target?: Partial<Element>) => {
@@ -26,7 +27,7 @@ describe('useKeyboard', () => {
     onNextPage: mockOnNextPage,
     onFullscreen: mockOnFullscreen,
     enabled: true,
-    readingDirection: 'rtl' as const,
+    readingDirection: 'rtl' as ReadingDirection,
     onZoomIn: mockOnZoomIn,
     onZoomOut: mockOnZoomOut,
   };
@@ -122,8 +123,7 @@ describe('useKeyboard', () => {
     });
 
     it('should not call onFullscreen when F11 is pressed and onFullscreen is not provided', () => {
-      const propsWithoutFullscreen = { ...defaultProps };
-      delete propsWithoutFullscreen.onFullscreen;
+      const propsWithoutFullscreen = { ...defaultProps, onFullscreen: undefined };
 
       renderHook(() => useKeyboard(propsWithoutFullscreen));
 
@@ -268,12 +268,12 @@ describe('useKeyboard', () => {
 
       const { rerender } = renderHook(
         (props) => useKeyboard(props),
-        { initialProps: { ...defaultProps, readingDirection: 'rtl' as const } }
+        { initialProps: { ...defaultProps, readingDirection: 'rtl' as ReadingDirection } }
       );
 
       expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
 
-      rerender({ ...defaultProps, readingDirection: 'ltr' as const });
+      rerender({ ...defaultProps, readingDirection: 'ltr' as ReadingDirection });
 
       expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
       expect(addEventListenerSpy).toHaveBeenCalledTimes(2);

--- a/src/hooks/usePdfDocument.test.ts
+++ b/src/hooks/usePdfDocument.test.ts
@@ -9,7 +9,7 @@ vi.mock('../utils/pdfWorker', () => ({
   },
 }));
 
-const mockPdfjsLib = vi.mocked(await import('../utils/pdfWorker')).default;
+const mockGetDocument = vi.mocked((await import('../utils/pdfWorker')).default.getDocument);
 
 // Mock console.error to avoid noise in tests
 const originalConsoleError = console.error;
@@ -51,9 +51,9 @@ describe('usePdfDocument', () => {
     const mockLoadingTask = {
       promise: Promise.resolve(mockPdf),
       onProgress: null as any,
-    };
+    } as any;
 
-    mockPdfjsLib.getDocument.mockReturnValue(mockLoadingTask);
+    mockGetDocument.mockReturnValue(mockLoadingTask);
 
     const { result } = renderHook(() => usePdfDocument());
 
@@ -85,9 +85,9 @@ describe('usePdfDocument', () => {
     const mockLoadingTask = {
       promise: Promise.resolve(mockPdf),
       onProgress: null as any,
-    };
+    } as any;
 
-    mockPdfjsLib.getDocument.mockReturnValue(mockLoadingTask);
+    mockGetDocument.mockReturnValue(mockLoadingTask);
 
     const { result } = renderHook(() => usePdfDocument());
 
@@ -113,9 +113,9 @@ describe('usePdfDocument', () => {
     const mockLoadingTask = {
       promise: Promise.resolve(mockPdf),
       onProgress: null as any,
-    };
+    } as any;
 
-    mockPdfjsLib.getDocument.mockReturnValue(mockLoadingTask);
+    mockGetDocument.mockReturnValue(mockLoadingTask);
 
     const { result } = renderHook(() => usePdfDocument());
 
@@ -142,9 +142,9 @@ describe('usePdfDocument', () => {
     const mockLoadingTask = {
       promise: Promise.reject(error),
       onProgress: null as any,
-    };
+    } as any;
 
-    mockPdfjsLib.getDocument.mockReturnValue(mockLoadingTask);
+    mockGetDocument.mockReturnValue(mockLoadingTask);
 
     const { result } = renderHook(() => usePdfDocument());
 
@@ -171,8 +171,8 @@ describe('usePdfDocument', () => {
     let mockLoadingTask = {
       promise: Promise.reject(invalidPdfError),
       onProgress: null as any,
-    };
-    mockPdfjsLib.getDocument.mockReturnValue(mockLoadingTask);
+    } as any;
+    mockGetDocument.mockReturnValue(mockLoadingTask);
 
     const pdfFile = new File(['content'], 'test.pdf', { type: 'application/pdf' });
 
@@ -187,8 +187,8 @@ describe('usePdfDocument', () => {
     mockLoadingTask = {
       promise: Promise.reject(encryptedError),
       onProgress: null as any,
-    };
-    mockPdfjsLib.getDocument.mockReturnValue(mockLoadingTask);
+    } as any;
+    mockGetDocument.mockReturnValue(mockLoadingTask);
 
     await act(async () => {
       await result.current.loadPdf(pdfFile);
@@ -201,8 +201,8 @@ describe('usePdfDocument', () => {
     mockLoadingTask = {
       promise: Promise.reject(networkError),
       onProgress: null as any,
-    };
-    mockPdfjsLib.getDocument.mockReturnValue(mockLoadingTask);
+    } as any;
+    mockGetDocument.mockReturnValue(mockLoadingTask);
 
     await act(async () => {
       await result.current.loadPdf(pdfFile);
@@ -220,9 +220,9 @@ describe('usePdfDocument', () => {
     const mockLoadingTask2 = {
       promise: Promise.resolve(mockPdf2),
       onProgress: null as any,
-    };
+    } as any;
 
-    mockPdfjsLib.getDocument.mockReturnValue(mockLoadingTask2);
+    mockGetDocument.mockReturnValue(mockLoadingTask2);
 
     const { result } = renderHook(() => usePdfDocument());
 
@@ -249,9 +249,9 @@ describe('usePdfDocument', () => {
     const mockLoadingTask = {
       promise: Promise.resolve(mockPdf),
       onProgress: null as any,
-    };
+    } as any;
 
-    mockPdfjsLib.getDocument.mockReturnValue(mockLoadingTask);
+    mockGetDocument.mockReturnValue(mockLoadingTask);
 
     const { result } = renderHook(() => usePdfDocument());
 


### PR DESCRIPTION
- Fix AppContext test: Add missing clearPdf mock in usePdfDocument hook
- Fix useKeyboard test: Replace delete operator with undefined assignment
- Fix useKeyboard test: Add proper ReadingDirection type imports and annotations
- Fix usePdfDocument test: Correct mock setup and add type assertions for PDF.js mocks

All tests passing (173 tests) and TypeScript compilation successful.

🤖 Generated with [Claude Code](https://claude.ai/code)